### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,5 +1,8 @@
 name: Pull Request Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/cerealean/bnch-dev-benchmarker/security/code-scanning/1](https://github.com/cerealean/bnch-dev-benchmarker/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. Since the workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow file (before `jobs:`), so it applies to all jobs unless overridden. This change should be made in `.github/workflows/pr-tests.yml`, above the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
