### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,6 +37,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/cerealean/bnch-dev-benchmarker/security/code-scanning/3](https://github.com/cerealean/bnch-dev-benchmarker/security/code-scanning/3)

To fix the problem, add a `permissions` block to the `build` job in `.github/workflows/ci-cd.yml` that restricts the GITHUB_TOKEN to the minimum required permissions. For a build job that only checks out code, installs dependencies, builds, and uploads artifacts, the minimal required permission is `contents: read`. This change should be made directly under the `build:` job definition, before the `steps:` block. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
