### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,6 +12,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
+      checks: write
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/cerealean/bnch-dev-benchmarker/security/code-scanning/2](https://github.com/cerealean/bnch-dev-benchmarker/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the `test` job in `.github/workflows/ci-cd.yml`. This block should restrict the job's permissions to the minimum required, which for a test job is typically `contents: read`. This change should be made directly under the `test:` job definition, at the same indentation level as `runs-on` and `strategy`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
